### PR TITLE
Added TensorFlow 2.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@
 **Abstract:** We study the problem of learning generative adversarial networks (GANs) for a rare class of an unlabeled dataset subject to a labeling budget. This problem is motivated from practical applications in domains including security (e.g., synthesizing packets for DNS amplification attacks), systems and networking (e.g., synthesizing workloads that trigger high resource usage), and machine learning (e.g., generating images from a rare class). Existing approaches are unsuitable, either requiring fully-labeled datasets or sacrificing the fidelity of the rare class for that of the common classes. We propose RareGAN, a novel synthesis of three key ideas: (1) extending conditional GANs to use labelled and unlabelled data for better generalization; (2) an active learning approach that requests the most useful labels; and (3) a weighted loss function to favor learning the rare class. We show that RareGAN achieves a better fidelity-diversity tradeoff on the rare class than prior work across different applications, budgets, rare class fractions, GAN losses, and architectures.
 
 ---
-This repo contains the codes for reproducing the experiments of our RareGAN in the paper. The codes were tested under Python 3.6.9, TensorFlow 1.15.2.
+This repo contains the codes for reproducing the experiments of our RareGAN in the paper. The codes were tested under Python 3.6.9 + TensorFlow 1.15.2 and Python 3.7.13 + TensorFlow 2.8.2.
 
 The code can be easily extended to your own applications, like [synthesizing images from rare classes](#extend-image), or [synthesizing data of more general formats (e.g., network packets, texts) for rare events (e.g., attacks)](#extend-network).
 
 ## Prerequisites
 
 The codes are based on [GPUTaskScheduler](https://github.com/fjxmlzn/GPUTaskScheduler) library, which helps you automatically schedule the jobs among GPU nodes. Please install it first. You may need to change GPU configurations according to the devices you have. The configurations are set in `config_generate_data.py` in each directory. Please refer to [GPUTaskScheduler's GitHub page](https://github.com/fjxmlzn/GPUTaskScheduler) for the details of how to make proper configurations.
+
+To run with TensorFlow 2, please install [TensorFlow-Slim](https://github.com/google-research/tf-slim) by `pip install tf-slim`.
 
 ## Image Experiments: Generating Rare Samples for CIFAR10 and MNIST
 

--- a/for_images/lib/gan/metrics.py
+++ b/for_images/lib/gan/metrics.py
@@ -6,6 +6,13 @@ if float('.'.join(tf.__version__.split('.')[:2])) < 1.15:
     tfgan = tf.contrib.gan
 else:
     import tensorflow_gan as tfgan
+if float('.'.join(tf.__version__.split('.')[:2])) < 2:
+    run_inception_fn = functools.partial(
+        tfgan.eval.run_inception, output_tensor="pool_3:0")
+else:
+    tf = tf.compat.v1
+    def run_inception_fn(tensor): return tfgan.eval.run_inception(tensor)[
+        'pool_3']
 
 
 class Metric(object):
@@ -105,8 +112,7 @@ class FrechetInceptionDistance(Metric):
         generated_images_list = array_ops.split(
             images, num_or_size_splits=1)
         activations = tf.map_fn(
-            fn=functools.partial(tfgan.eval.run_inception,
-                                 output_tensor="pool_3:0"),
+            fn=run_inception_fn,
             elems=array_ops.stack(generated_images_list),
             parallel_iterations=8,
             back_prop=False,

--- a/for_images/lib/gan/networks.py
+++ b/for_images/lib/gan/networks.py
@@ -1,4 +1,4 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import os
 
 from .ops import linear, batch_norm, deconv2d, conv2d, lrelu

--- a/for_images/lib/gan/ops.py
+++ b/for_images/lib/gan/ops.py
@@ -1,5 +1,11 @@
 import tensorflow as tf
 import numpy as np
+if float('.'.join(tf.__version__.split('.')[:2])) >= 2:
+    tf = tf.compat.v1
+    import tf_slim as slim
+    batch_norm_fn = slim.batch_norm
+else:
+    batch_norm_fn = tf.contrib.layers.batch_norm
 
 
 def linear(input_, output_size, scope_name="linear"):
@@ -31,13 +37,13 @@ class batch_norm(object):
             self._name = name
 
     def __call__(self, x, train=True):
-        return tf.contrib.layers.batch_norm(x,
-                                            decay=self._momentum,
-                                            updates_collections=None,
-                                            epsilon=self._epsilon,
-                                            scale=True,
-                                            is_training=train,
-                                            scope=self._name)
+        return batch_norm_fn(x,
+                             decay=self._momentum,
+                             updates_collections=None,
+                             epsilon=self._epsilon,
+                             scale=True,
+                             is_training=train,
+                             scope=self._name)
 
 
 def lrelu(x, leak=0.2, name="lrelu"):

--- a/for_images/lib/gan/raregan.py
+++ b/for_images/lib/gan/raregan.py
@@ -1,4 +1,4 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import numpy as np
 import os
 import math

--- a/for_images/scripts/CIFAR10/task_generate_data.py
+++ b/for_images/scripts/CIFAR10/task_generate_data.py
@@ -4,7 +4,7 @@ from gpu_task_scheduler.gpu_task import GPUTask
 class Task(GPUTask):
     def main(self):
         import random
-        import tensorflow as tf
+        import tensorflow.compat.v1 as tf
         import os
         import sys
         import numpy as np

--- a/for_images/scripts/MNIST/task_generate_data.py
+++ b/for_images/scripts/MNIST/task_generate_data.py
@@ -4,7 +4,7 @@ from gpu_task_scheduler.gpu_task import GPUTask
 class Task(GPUTask):
     def main(self):
         import random
-        import tensorflow as tf
+        import tensorflow.compat.v1 as tf
         import os
         import sys
         import numpy as np

--- a/for_systems/lib/gan/networks.py
+++ b/for_systems/lib/gan/networks.py
@@ -1,4 +1,4 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import os
 
 from .ops import linear, batch_norm, lrelu

--- a/for_systems/lib/gan/ops.py
+++ b/for_systems/lib/gan/ops.py
@@ -1,6 +1,11 @@
 import tensorflow as tf
 import numpy as np
-
+if float('.'.join(tf.__version__.split('.')[:2])) >= 2:
+    tf = tf.compat.v1
+    import tf_slim as slim
+    batch_norm_fn = slim.batch_norm
+else:
+    batch_norm_fn = tf.contrib.layers.batch_norm
 
 def linear(input_, output_size, scope_name="linear"):
     with tf.variable_scope(scope_name):
@@ -31,13 +36,13 @@ class batch_norm(object):
             self._name = name
 
     def __call__(self, x, train=True):
-        return tf.contrib.layers.batch_norm(x,
-                                            decay=self._momentum,
-                                            updates_collections=None,
-                                            epsilon=self._epsilon,
-                                            scale=True,
-                                            is_training=train,
-                                            scope=self._name)
+        return batch_norm_fn(x,
+                             decay=self._momentum,
+                             updates_collections=None,
+                             epsilon=self._epsilon,
+                             scale=True,
+                             is_training=train,
+                             scope=self._name)
 
 
 def lrelu(x, leak=0.2, name="lrelu"):

--- a/for_systems/lib/gan/raregan.py
+++ b/for_systems/lib/gan/raregan.py
@@ -1,4 +1,4 @@
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import numpy as np
 import os
 import math

--- a/for_systems/scripts/DNS/task_generate_data.py
+++ b/for_systems/scripts/DNS/task_generate_data.py
@@ -4,7 +4,7 @@ from gpu_task_scheduler.gpu_task import GPUTask
 class Task(GPUTask):
     def main(self):
         import random
-        import tensorflow as tf
+        import tensorflow.compat.v1 as tf
         import os
         import sys
         import numpy as np

--- a/for_systems/scripts/PC/task_generate_data.py
+++ b/for_systems/scripts/PC/task_generate_data.py
@@ -4,7 +4,7 @@ from gpu_task_scheduler.gpu_task import GPUTask
 class Task(GPUTask):
     def main(self):
         import random
-        import tensorflow as tf
+        import tensorflow.compat.v1 as tf
         import os
         import sys
         import numpy as np


### PR DESCRIPTION
The modification was tested with Python 3.7.13 + TensorFlow 2.8.2 and Python 3.6.9 + TensorFlow 1.15. Both were trained with MNIST dataset. Training successfully started and returned expected results. Note: for TensorFlow 2.x, `tf_slim` is needed to support deprecated functions used in `tf.contrib`.